### PR TITLE
gracefully delete artifactory group

### DIFF
--- a/plugin/artifactory_client.go
+++ b/plugin/artifactory_client.go
@@ -120,7 +120,19 @@ func (ac *artifactoryClient) CreateOrReplaceGroup(role *RoleStorageEntry) error 
 }
 
 func (ac *artifactoryClient) DeleteGroup(role *RoleStorageEntry) error {
-	return ac.client.DeleteGroup(groupName(role))
+	params := services.GroupParams{
+		GroupDetails: services.Group{
+			Name: groupName(role),
+		},
+	}
+	group, err := ac.client.GetGroup(params)
+	if err != nil {
+		return err
+	}
+	if group != nil {
+		return ac.client.DeleteGroup(group.Name)
+	}
+	return nil
 }
 
 func (ac *artifactoryClient) CreateOrUpdatePermissionTarget(role *RoleStorageEntry, pt *PermissionTarget, ptName string) error {


### PR DESCRIPTION
deletion of group produced error when there's no group to delete. this makes sure a group exists before performing deletion of group. otherwise, don't perform deletion and return nil