### PR TITLE
discard artifactory log

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,6 +21,18 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Set Go Version
+      run: echo "GO_VERSION=$(grep "go 1." go.mod | cut -d " " -f 2)" >> $GITHUB_ENV
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.GO_VERSION }}
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:

--- a/plugin/artifactory_client.go
+++ b/plugin/artifactory_client.go
@@ -17,6 +17,7 @@ package artifactorysecrets
 import (
 	"context"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/jfrog/jfrog-client-go/artifactory"
@@ -55,8 +56,7 @@ func NewClient(config *ConfigStorageEntry) (Client, error) {
 		expiration: time.Now().Add(clientTTL),
 	}
 
-	// TODO: need to figure out
-	log.SetLogger(log.NewLogger(log.INFO, nil))
+	log.SetLogger(log.NewLogger(log.INFO, io.Discard))
 
 	artifactoryDetails := auth.NewArtifactoryDetails()
 	artifactoryDetails.SetUrl(config.BaseURL)


### PR DESCRIPTION
artifactory client log is directed to stderr and it hits size. when it's directed to stdout to debug, it works fine. In this PR, we redirect to io.Discard