### PR TITLE
rollback with wal

### DIFF
--- a/docs/design-principles.md
+++ b/docs/design-principles.md
@@ -53,3 +53,11 @@ Until rollback is implemented, we ensure that least privileges at the time of ro
 - perform removal of excess permission targets if there's any
 - perform creation/update of permission targets
 - perform role creation/update
+
+### Role Creation May Partially Fail
+
+Every group creation and permission target creation is an Artifactory API call per resource. If an API call to one of these resources fails, the role creation fails and Vault will attempt to rollback.
+
+These rollbackls are API calls, so they may also fail. The secrets engine uses WAL to ensure that unused permission targets are cleaned up. In the case of api failures, you may need to clean these up manually.
+
+Rollbacks are using Vault's Write Ahead Logs(WAL) underlying mechanism.  

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/andybalholm/brotli v1.0.2 // indirect
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/google/uuid v1.3.0
+	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-immutable-radix v1.2.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-plugin v1.2.2 // indirect

--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/locksutil"
@@ -103,7 +104,9 @@ func Backend(conf *logical.BackendConfig) *ArtifactoryBackend {
 			pathRoleList(backend),
 			pathToken(backend),
 		),
-		Invalidate: backend.invalidate,
+		Invalidate:        backend.invalidate,
+		WALRollback:       backend.walRollback,
+		WALRollbackMinAge: 30 * time.Second,
 	}
 
 	return backend

--- a/plugin/rollback.go
+++ b/plugin/rollback.go
@@ -1,0 +1,124 @@
+package artifactorysecrets
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/mitchellh/mapstructure"
+)
+
+const (
+	walTypeGroup            = "group"
+	walTypePermissionTarget = "permission_target"
+)
+
+func (backend *ArtifactoryBackend) walRollback(ctx context.Context, req *logical.Request, kind string, data interface{}) error {
+	switch kind {
+	case walTypeGroup:
+		return backend.groupRollback(ctx, req, data)
+	case walTypePermissionTarget:
+		return backend.permissionTargetRollback(ctx, req, data)
+	default:
+		return fmt.Errorf("unknown type to rollback")
+	}
+}
+
+type walGroup struct {
+	RoleName string
+	ID       string
+}
+
+type walPermissionTarget struct {
+	RoleName             string
+	PermissionTargetName string
+	Index                int
+}
+
+func (backend *ArtifactoryBackend) groupRollback(ctx context.Context, req *logical.Request, data interface{}) error {
+
+	var entry walGroup
+	if err := mapstructure.Decode(data, &entry); err != nil {
+		return err
+	}
+
+	if entry.RoleName == "" {
+		return fmt.Errorf("missing role name")
+	}
+
+	lock := backend.roleLock(entry.RoleName)
+	lock.RLock()
+	defer lock.RUnlock()
+
+	// If group is still being used, WAL entry was not deleted properly
+	// after a successful operations. Remove WAL entry
+	role, err := getRoleEntry(ctx, req.Storage, entry.RoleName)
+	if err != nil {
+		return err
+	}
+	if role != nil && entry.ID == role.RoleID {
+		// still being used - don't delete this group
+		return nil
+	}
+
+	// delete group
+	ac, err := backend.getClient(ctx, req.Storage)
+	if err != nil {
+		return fmt.Errorf("failed to obtain artifactory client - %s", err.Error())
+	}
+
+	backend.Logger().Debug("Deleting group by WAL rollback", "name", entry.RoleName)
+	return backend.deleteGroup(ctx, ac, entry.ID)
+}
+
+func (backend *ArtifactoryBackend) permissionTargetRollback(ctx context.Context, req *logical.Request, data interface{}) error {
+	var entry walPermissionTarget
+	if err := mapstructure.Decode(data, &entry); err != nil {
+		return err
+	}
+
+	if entry.RoleName == "" {
+		return fmt.Errorf("missing role name")
+	}
+
+	lock := backend.roleLock(entry.RoleName)
+	lock.RLock()
+	defer lock.RUnlock()
+
+	// If group is still being used, WAL entry was not deleted properly
+	// after a successful operations. Remove WAL entry
+	role, err := getRoleEntry(ctx, req.Storage, entry.RoleName)
+	if err != nil {
+		return err
+	}
+	if role != nil && entry.Index > len(role.PermissionTargets) {
+		// Still being used
+		return nil
+	}
+
+	// delete permission target
+	ac, err := backend.getClient(ctx, req.Storage)
+	if err != nil {
+		return fmt.Errorf("failed to obtain artifactory client - %s", err.Error())
+	}
+
+	backend.Logger().Debug("Deleting permission target by WAL rollback", "name", entry.PermissionTargetName)
+	return backend.deletePermissionTarget(ctx, ac, entry.PermissionTargetName)
+}
+
+func (backend *ArtifactoryBackend) deleteGroup(ctx context.Context, ac Client, roleID string) error {
+	if roleID == "" {
+		return nil
+	}
+
+	roleEntry := RoleStorageEntry{RoleID: roleID}
+	return ac.DeleteGroup(&roleEntry)
+}
+
+func (backend *ArtifactoryBackend) deletePermissionTarget(ctx context.Context, ac Client, ptName string) error {
+	if ptName == "" {
+		return nil
+	}
+
+	return ac.DeletePermissionTarget(ptName)
+}


### PR DESCRIPTION
adding rollback capabilities in case of failures

- group should be removed if corresponding role doesn't exist
- permission targets should be removed if corresponding group doesn't exist

