### PR TITLE
use sha256 of role name for role id

### DIFF
--- a/plugin/path_role.go
+++ b/plugin/path_role.go
@@ -16,7 +16,6 @@ package artifactorysecrets
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -154,8 +153,7 @@ func (backend *ArtifactoryBackend) pathRoleCreateUpdate(ctx context.Context, req
 		role = &RoleStorageEntry{
 			Name: roleName,
 		}
-		roleID := sha256.Sum256([]byte(roleName))
-		role.RoleID = fmt.Sprintf("%x", roleID[:32])
+		role.RoleID = roleID(roleName)
 	}
 
 	isCreate := req.Operation == logical.CreateOperation

--- a/plugin/path_role.go
+++ b/plugin/path_role.go
@@ -16,11 +16,11 @@ package artifactorysecrets
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -154,8 +154,8 @@ func (backend *ArtifactoryBackend) pathRoleCreateUpdate(ctx context.Context, req
 		role = &RoleStorageEntry{
 			Name: roleName,
 		}
-		roleID, _ := uuid.NewUUID()
-		role.RoleID = roleID.String()
+		roleID := sha256.Sum256([]byte(roleName))
+		role.RoleID = fmt.Sprintf("%x", roleID[:32])
 	}
 
 	isCreate := req.Operation == logical.CreateOperation

--- a/plugin/util.go
+++ b/plugin/util.go
@@ -29,6 +29,7 @@ const (
 	tokenUsernamePrefix  = "auto-vault-plugin"
 	tokenUsernameMaxLen  = 58
 	tokenUsernameHashLen = 8
+	roleIDHashLen        = 32
 )
 
 func groupName(roleEntry *RoleStorageEntry) string {
@@ -37,6 +38,11 @@ func groupName(roleEntry *RoleStorageEntry) string {
 
 func permissionTargetName(roleName string, index int) string {
 	return fmt.Sprintf("%s.pt%d.%s", pluginPrefix, index, roleName)
+}
+
+func roleID(roleName string) string {
+	roleID := sha256.Sum256([]byte(roleName))
+	return fmt.Sprintf("%x", roleID)[:roleIDHashLen]
 }
 
 func tokenUsername(roleName string) string {

--- a/plugin/util_test.go
+++ b/plugin/util_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const maxArtifactoryNameLen = 64
+
 func TestValidatePermissionTarget(t *testing.T) {
 
 	t.Parallel()
@@ -122,6 +124,31 @@ func TestConvertPermissionTarget(t *testing.T) {
 		assert.Len(t, cpt.Repo.Actions.Groups["vault-plugin.1234567890"], 2, "incorrect number of operations")
 		assert.ElementsMatch(t, []string{"read", "write"}, cpt.Repo.Actions.Groups["vault-plugin.1234567890"])
 	})
+}
+
+func TestRoleID(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		maxLen int
+	}{
+		{
+			name:   "roleID is less than 64 chars (artifactory max)",
+			input:  "rolename-long-but-less-than-max",
+			maxLen: maxArtifactoryNameLen,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := roleID(test.input)
+			checkTokenUsernameLength(t, actual)
+			if len(actual) > test.maxLen {
+				t.Errorf("roleID: %v, len(roleID): %v", actual, len(actual))
+			}
+		})
+
+	}
 }
 
 func TestTokenUserName(t *testing.T) {


### PR DESCRIPTION
This should avoid issues that come up when running this plugin with two vault instances against the same artifactory instance.