### PR TITLE
Allow for static groups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ vault-only: build
 dev: tools build-linux
 	@./scripts/init_dev.sh
 
+reload: tools build-linux
+	@./scripts/setup_dev_vault.sh
+
 clean-dev:
 	@cd scripts && docker compose down -v
 
@@ -72,4 +75,4 @@ tools: .tools .tools/gocover-cobertura .tools/gocovmerge .tools/golangci-lint .t
 	curl -so .tools/vault.zip -sSL https://releases.hashicorp.com/vault/$(VAULT_VERSION)/vault_$(VAULT_VERSION)_$(VAULT_PLATFORM)_amd64.zip
 	(cd .tools && unzip -o vault.zip && rm vault.zip)
 
-.PHONY: all get build build-linux publish lint test test-artacc test-vaultacc report vault-only dev clean-dev clean-all tools
+.PHONY: all get build build-linux publish lint test test-artacc test-vaultacc report vault-only dev reload clean-dev clean-all tools

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<!-- omit in toc -->
 # vault-plugin-secrets-artifactory
 
 [![build-status-badge]][actions-page]
@@ -10,6 +9,7 @@ This is a backend plugin to be used with Vault. This plugin generates one-time a
 
 [Design doc][design-doc]
 
+- [Differences between JFrog's Vault Plugin](#differences-between-jfrogs-vault-plugin)
 - [Requirements](#requirements)
 - [Getting Started](#getting-started)
   - [Usage](#usage)
@@ -19,8 +19,17 @@ This is a backend plugin to be used with Vault. This plugin generates one-time a
 - [Development](#development)
   - [Full dev environment](#full-dev-environment)
   - [Developing with an existing Artifactory instance](#developing-with-an-existing-artifactory-instance)
+  - [Reloading plugin](#reloading-plugin)
   - [Tests](#tests)
 - [License](#license)
+
+## Differences between JFrog's Vault Plugin
+
+JFrog has their [own vault plugin](https://github.com/jfrog/vault-plugin-secrets-artifactory/).  The
+main difference between that plugin and this one is the dynamic group/permission target generation.
+
+This plugin generates permission targets and a group to link the token with the desired permissions,
+in addition to being able to specify a pre-existing group.
 
 ## Requirements
 
@@ -55,8 +64,14 @@ $ vault write artifactory/config base_url="https://artifactory.example.com/artif
 $ vault path-help artifactory/
 $ vault path-help artifactory/config
 
-# create a role
+# create a role with permissions targets
 $ vault write artifactory/roles/ci-role token_ttl=600 permission_targets=@scripts/sample_permission_targets.json
+
+# create a role with permission targets and additional pre-existing static groups
+$ vault write artifactory/roles/ci-role token_ttl=600 permission_targets=@scripts/sample_permission_targets.json groups=group1,group2,group3
+
+# create a role with pre-existing static groups only
+$ vault write artifactory/roles/ci-role token_ttl=600 groups=group1,group2,group3
 
 # generate an ephemeral artifactory token
 $ vault write artifactory/token/ci-role ttl=60
@@ -191,6 +206,16 @@ export ARTIFACTORY_BEARER_TOKEN=TOKEN
 ```
 
 You can then create a role and issue a token following above usage.
+
+### Reloading plugin
+
+To quickly test changes to the plugin (using the docker environment), run:
+
+```
+make reload
+```
+
+This will re-compile, re-register, and reload the plugin.
 
 ### Tests
 

--- a/plugin/artifactory_client.go
+++ b/plugin/artifactory_client.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/jfrog/jfrog-client-go/access"
@@ -185,9 +186,15 @@ func (ac *artifactoryClient) DeletePermissionTarget(ptName string) error {
 func (ac *artifactoryClient) CreateToken(tokenReq TokenCreateEntry, role *RoleStorageEntry) (auth.CreateTokenResponseData, error) {
 	expiresIn := uint(tokenReq.TTL.Seconds())
 
+	var groups []string
+	if len(role.PermissionTargets) > 0 {
+		groups = append(groups, groupName(role))
+	}
+	groups = append(groups, role.Groups...)
+
 	params := accessservices.CreateTokenParams{
 		CommonTokenParams: auth.CommonTokenParams{
-			Scope:     fmt.Sprintf("applied-permissions/groups:%s", groupName(role)),
+			Scope:     fmt.Sprintf("applied-permissions/groups:%s", strings.Join(groups, ",")),
 			ExpiresIn: &expiresIn,
 			TokenType: "access_token",
 			Audience:  "*@*",

--- a/plugin/path_role_test.go
+++ b/plugin/path_role_test.go
@@ -367,7 +367,7 @@ func TestArtAccPermissionTargets(t *testing.T) {
 	})
 }
 
-func TestPathRoleFail(t *testing.T) {
+func TestPathRole(t *testing.T) {
 	t.Parallel()
 	req, backend := newArtMockEnv(t)
 	conf := map[string]interface{}{
@@ -448,11 +448,11 @@ func TestPathRoleFail(t *testing.T) {
 		require.True(t, resp.IsError(), "expecting error")
 
 		actualErr := resp.Data["error"].(string)
-		expected := "permission targets are required for new role"
+		expected := "permission targets and/or groups are required to create or update a role"
 		assert.Contains(t, actualErr, expected)
 	})
 
-	t.Run("empty_permission_targets", func(t *testing.T) {
+	t.Run("empty permission targets and groups", func(t *testing.T) {
 		data := make(map[string]interface{})
 		roleName := "test_role1"
 		data["permission_targets"] = ""
@@ -461,7 +461,7 @@ func TestPathRoleFail(t *testing.T) {
 		require.True(t, resp.IsError(), "expecting error")
 
 		actualErr := resp.Data["error"].(string)
-		expected := "permission targets are empty"
+		expected := "permission targets and groups are empty"
 		assert.Contains(t, actualErr, expected)
 	})
 
@@ -527,6 +527,21 @@ func TestPathRoleFail(t *testing.T) {
 		actualErr := resp.Data["error"].(string)
 		expected := "operation 'invalidop' is not allowed"
 		assert.Contains(t, actualErr, expected)
+	})
+
+	t.Run("static group only role succeeds", func(t *testing.T) {
+		data := make(map[string]interface{})
+		roleName := "test_role1"
+		data["groups"] = []string{"testgroup1", "testgroup2"}
+		data["name"] = roleName
+		resp, err := testRoleCreate(req, backend, t, roleName, data)
+		require.NoError(t, err)
+		require.False(t, resp.IsError(), "expecting no response error")
+
+		rawGroups := resp.Data["groups"]
+		groups := rawGroups.([]string)
+
+		assert.Len(t, groups, 2)
 	})
 }
 

--- a/plugin/role.go
+++ b/plugin/role.go
@@ -30,7 +30,6 @@ const (
 )
 
 type RoleStorageEntry struct {
-	// `json:"" structs:"" mapstructure:""`
 	// The UUID that defines this role
 	RoleID string `json:"role_id" structs:"role_id" mapstructure:"role_id"`
 
@@ -42,6 +41,13 @@ type RoleStorageEntry struct {
 
 	// The provided name for the role
 	Name string `json:"name" structs:"name" mapstructure:"name"`
+
+	// Groups are optional pre-existing static Artifactory groups to associate
+	// with the role and attach to the generated token scope.
+	//
+	// These groups are separate from the generated group that is created to
+	// accompany any configured permission targets.
+	Groups []string `json:"groups,omitempty" structs:"groups" mapstructure:"groups,omitempty"`
 
 	RawPermissionTargets string
 	PermissionTargets    []PermissionTarget
@@ -56,11 +62,13 @@ func (role RoleStorageEntry) validate() error {
 	if role.RoleID == "" {
 		err = multierror.Append(err, errors.New("role id is empty"))
 	}
-	if role.RawPermissionTargets == "" {
-		err = multierror.Append(err, errors.New("raw permission targets are empty"))
-	}
-	if role.PermissionTargets == nil {
-		err = multierror.Append(err, errors.New("permission targets are empty"))
+	if len(role.Groups) == 0 {
+		if role.RawPermissionTargets == "" {
+			err = multierror.Append(err, errors.New("raw permission targets are empty"))
+		}
+		if role.PermissionTargets == nil {
+			err = multierror.Append(err, errors.New("permission targets are empty and groups are empty"))
+		}
 	}
 	return err.ErrorOrNil()
 }

--- a/scripts/setup_dev_artifactory.sh
+++ b/scripts/setup_dev_artifactory.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+: "${ARTIFACTORY_LICENSE_KEY:?license key is required}"
+
 ARTIFACTORY_URL="http://localhost:8081/artifactory/"
 ACCESS_URL="http://localhost:8082/access/"
 ARTIFACTORY_USER="admin"
@@ -35,6 +37,12 @@ setup_artifactory() {
     echo
   done
 
+  # create some static groups to test with
+  for group in "group1" "group2" "group3"; do
+    payload=$(jq -n --arg name "$group" '{"name": $name, "description": "\( $name ) group", "auto_join": false}')
+    curl -sS -XPOST -H "$auth_header" -H "$content_header" "${ACCESS_URL}api/v2/groups" -d "$payload" || true
+  done
+
   # # create a new admin user for UI use
   # password=$(openssl rand -base64 8)
   # payload=$(jq -n --arg pw "$password" '{userName: "dev", email: "dev@dev.net", password: $pw, admin: true}')
@@ -53,4 +61,5 @@ setup_artifactory >&2
 echo export ARTIFACTORY_USER=\"$ARTIFACTORY_USER\"\;
 echo export ARTIFACTORY_PASSWORD=\"$ARTIFACTORY_PASSWORD\"\;
 echo export ARTIFACTORY_URL=\"$ARTIFACTORY_URL\"\;
+echo export ACCESS_URL=\"$ACCESS_URL\"\;
 echo export ARTIFACTORY_BEARER_TOKEN=\"$ARTIFACTORY_BEARER_TOKEN\"\;


### PR DESCRIPTION
This adds the ability to include pre-existing Artifactory groups in a generated token, independent of the dynamically-generated group and permissions.

### Before:
```sh
➜  vault write artifactory-cloud/roles/role1 token_ttl=600 permission_targets=@scripts/sample_permission_targets.json
Key                   Value
---                   -----
permission_targets    [
  {
    "repo": {
      "include_patterns": ["@my-scoped/my-scoped-package/**"],
      "exclude_patterns": [""],
      "repositories": ["npm-test-west-local", "npm-test-east-local"],
      "operations": ["read", "write", "annotate"]
    }
  },
  ...
]
role_id               07ffa23817eb0c999f8e126a39db481e
role_name             role1

➜  vault write artifactory-cloud/token/role1 ttl=60
Key             Value
---             -----
access_token    eyJ2Z...
username        auto-vault-plugin.role1
```
Acess token payload (before):
```json
{
  "sub": "jfac@01hq2njf0pvbcv0g0m368z0s0z/users/auto-vault-plugin.role1",
  "scp": "applied-permissions/groups:vault-plugin.07ffa23817eb0c999f8e126a39db481e",
  "aud": "*@*",
  "iss": "jfac@01hq2njf0pvbcv0g0m368z0s0z",
  "exp": 1708580644,
  "iat": 1708580584,
  "jti": "15948195-00ae-4eb9-a9fa-038d4f92e48f"
}
```

### After

With static groups and permission targets:
```sh
➜  vault write artifactory-cloud/roles/role1 token_ttl=600 permission_targets=@scripts/sample_permission_targets.json groups=group1,group2
Key                   Value
---                   -----
groups                [group1 group2]
permission_targets    [
  {
    "repo": {
      "include_patterns": ["@my-scoped/my-scoped-package/**"],
      "exclude_patterns": [""],
      "repositories": ["npm-test-west-local", "npm-test-east-local"],
      "operations": ["read", "write", "annotate"]
    }
  },
 ...
]
role_id               07ffa23817eb0c999f8e126a39db481e
role_name             role1

```

Access token payload:

```json
{
  "sub": "jfac@01hq2njf0pvbcv0g0m368z0s0z/users/auto-vault-plugin.role1",
  "scp": "applied-permissions/groups:vault-plugin.07ffa23817eb0c999f8e126a39db481e,group1,group2",
  "aud": "*@*",
  "iss": "jfac@01hq2njf0pvbcv0g0m368z0s0z",
  "exp": 1708580899,
  "iat": 1708580839,
  "jti": "568b29a4-e391-4fb0-a2f3-268f603be99f"
}

```

With static groups only:

```
➜  vault write artifactory-cloud/roles/role2 token_ttl=600 groups=group1,group2                                                                                                    
Key                   Value
---                   -----
groups                [group1 group2]
permission_targets    n/a
role_id               e928e822a330518bb944af5aeca8cf99
role_name             role2
```

Access token payload:

```json
{
  "sub": "jfac@01hq2njf0pvbcv0g0m368z0s0z/users/auto-vault-plugin.role2",
  "scp": "applied-permissions/groups:group1,group2",
  "aud": "*@*",
  "iss": "jfac@01hq2njf0pvbcv0g0m368z0s0z",
  "exp": 1708581046,
  "iat": 1708580986,
  "jti": "54b84818-9734-43c0-b6e6-d452696cce35"
}

```
